### PR TITLE
fix(deps): bump pytest to 7.1.2 [GHSA-6w46-j5rx-g56g]

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = []
 
 [project.optional-dependencies]
 dev = [
-    "pytest>=7.0.0",
+    "pytest==7.1.2",
     "pytest-asyncio>=0.21.0",
     "hypothesis>=6.0",
     "ruff>=0.4.0",


### PR DESCRIPTION
## AI AutoFix

Resolves **GHSA-6w46-j5rx-g56g** (MODERATE) in `pytest`.

Bumps `pytest` to `7.1.2`.

> ⚠️  **AI-sourced fix version** — OSV did not list a fixed version for this advisory. The version above comes from an OpenAI lookup against training-data knowledge of the GitHub advisory. Verify it's a real published release before merging.

Merge once CI is green.

---
_Proposal accepted by user click in Flyto Code._