### PR TITLE
security(api): bound HTTP server (DoS) + XXE-safe XML parsing (H-10 / P1-8)

### DIFF
--- a/src/api_server.py
+++ b/src/api_server.py
@@ -29,9 +29,37 @@ import argparse
 import json
 import logging
 import os
-from http.server import BaseHTTPRequestHandler, HTTPServer
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
 from urllib.parse import urlparse
+
+# Cap request bodies so a single connection cannot force an unbounded
+# self.rfile.read() allocation (memory-exhaustion DoS). 4 MiB is generous for
+# the tiny JSON these endpoints accept.
+MAX_BODY_BYTES = 4 * 1024 * 1024
+
+# Bound how long a slow/incomplete request may hold a worker thread (slow-loris).
+SOCKET_TIMEOUT_SECONDS = 30
+
+# Upper bound on search result counts a client may request.
+MAX_SEARCH_RESULTS = 100
+
+
+class _BadRequest(Exception):
+    """Malformed request body — surfaced as HTTP 400."""
+
+
+class _PayloadTooLarge(Exception):
+    """Request body over MAX_BODY_BYTES — surfaced as HTTP 413."""
+
+
+def _clamp_max_results(value, default: int = 10) -> int:
+    """Coerce a client-supplied max_results into [1, MAX_SEARCH_RESULTS]."""
+    try:
+        n = int(value)
+    except (TypeError, ValueError):
+        return default
+    return max(1, min(n, MAX_SEARCH_RESULTS))
 
 _ALLOWED_ORIGINS: set[str] = set(
     origin.strip()
@@ -368,6 +396,10 @@ def get_stats() -> dict:
 class APIHandler(BaseHTTPRequestHandler):
     """HTTP request handler"""
 
+    # StreamRequestHandler.setup() applies this as the per-connection socket
+    # timeout, bounding slow-loris reads that would otherwise pin a worker.
+    timeout = SOCKET_TIMEOUT_SECONDS
+
     def _get_cors_origin(self) -> str | None:
         """Return the request Origin if it is in the allowed set, else None."""
         origin = self.headers.get("Origin", "")
@@ -391,11 +423,23 @@ class APIHandler(BaseHTTPRequestHandler):
         self.wfile.write(json.dumps(data, ensure_ascii=False, indent=2).encode("utf-8"))
 
     def _read_json(self) -> dict:
-        content_length = int(self.headers.get("Content-Length", 0))
-        if content_length > 0:
-            body = self.rfile.read(content_length)
+        try:
+            content_length = int(self.headers.get("Content-Length", 0))
+        except (TypeError, ValueError):
+            raise _BadRequest("invalid Content-Length")
+        if content_length < 0:
+            raise _BadRequest("invalid Content-Length")
+        if content_length > MAX_BODY_BYTES:
+            raise _PayloadTooLarge(
+                f"request body {content_length} exceeds {MAX_BODY_BYTES}-byte limit"
+            )
+        if content_length == 0:
+            return {}
+        body = self.rfile.read(content_length)
+        try:
             return json.loads(body.decode("utf-8"))
-        return {}
+        except (ValueError, UnicodeDecodeError) as e:
+            raise _BadRequest(f"invalid JSON body: {e}")
 
     def do_OPTIONS(self):
         self.send_response(200)
@@ -425,11 +469,18 @@ class APIHandler(BaseHTTPRequestHandler):
 
     def do_POST(self):
         path = urlparse(self.path).path
-        body = self._read_json()
+        try:
+            body = self._read_json()
+        except _PayloadTooLarge as e:
+            self._send_json({"error": str(e)}, 413)
+            return
+        except _BadRequest as e:
+            self._send_json({"error": str(e)}, 400)
+            return
 
         if path == "/search":
             query = body.get("query", "")
-            max_results = body.get("max_results", 10)
+            max_results = _clamp_max_results(body.get("max_results", 10))
             self._send_json(search_by_keyword(query, max_results))
 
         elif path == "/file/info":
@@ -454,10 +505,15 @@ class APIHandler(BaseHTTPRequestHandler):
 def main():
     parser = argparse.ArgumentParser(description="Flyto Indexer HTTP API Server")
     parser.add_argument("--port", type=int, default=8765, help="Server port")
-    parser.add_argument("--host", default="0.0.0.0", help="Server host")
+    parser.add_argument(
+        "--host",
+        default="127.0.0.1",
+        help="Server host (defaults to loopback; this service has no auth)",
+    )
     args = parser.parse_args()
 
-    server = HTTPServer((args.host, args.port), APIHandler)
+    server = ThreadingHTTPServer((args.host, args.port), APIHandler)
+    server.timeout = SOCKET_TIMEOUT_SECONDS
     logger.info(f"Flyto Indexer API Server running at http://{args.host}:{args.port}")
     logger.info(f"OpenAPI spec: http://{args.host}:{args.port}/openapi.json")
     logger.info(f"Health check: http://{args.host}:{args.port}/health")

--- a/src/dependency_scanner.py
+++ b/src/dependency_scanner.py
@@ -17,6 +17,11 @@ except ModuleNotFoundError:
     import tomli as tomllib  # type: ignore[no-redef]  # Python 3.10 compat
 import xml.etree.ElementTree as ET
 from dataclasses import dataclass, field, asdict
+
+try:
+    from .safe_xml import safe_parse_xml, UnsafeXMLError
+except ImportError:  # imported as a top-level module (src/ on sys.path)
+    from safe_xml import safe_parse_xml, UnsafeXMLError
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Optional
@@ -527,8 +532,8 @@ def _parse_pom_xml(file_path: Path, project_path: Path) -> list[PackageDependenc
     deps = []
     source = _rel_path(file_path, project_path)
     try:
-        tree = ET.parse(file_path)
-    except (ET.ParseError, OSError) as e:
+        tree = safe_parse_xml(file_path)
+    except (ET.ParseError, OSError, UnsafeXMLError) as e:
         logger.warning("Failed to parse %s: %s", file_path, e)
         return deps
 

--- a/src/safe_xml.py
+++ b/src/safe_xml.py
@@ -1,0 +1,47 @@
+"""Dependency-free safe XML parsing for ingested, untrusted repository files.
+
+The indexer parses XML (pom.xml, coverage.xml) from repositories it does not
+control. Stdlib xml.etree is vulnerable to entity-expansion ("billion laughs")
+and external-entity (XXE) attacks via DTDs. This module keeps the package
+dependency-free (defusedxml would be the alternative) by:
+
+  1. capping the input size, and
+  2. rejecting any DTD / entity declaration up front — neither pom.xml nor
+     coverage.xml legitimately uses a DOCTYPE or <!ENTITY>, so a hard reject is
+     both safe and correct for these formats.
+
+External and internal entity attacks both require a DTD/DOCTYPE or an <!ENTITY>
+declaration, so rejecting those closes the class outright.
+"""
+
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+# 25 MiB is far above any real pom.xml / coverage.xml while still bounding the
+# memory a malicious file can force us to read and parse.
+DEFAULT_MAX_XML_BYTES = 25 * 1024 * 1024
+
+
+class UnsafeXMLError(ValueError):
+    """Raised when an XML input exceeds the size cap or declares a DTD/entity."""
+
+
+def safe_parse_xml(path, max_bytes: int = DEFAULT_MAX_XML_BYTES) -> ET.ElementTree:
+    """Parse an XML file, refusing oversized inputs and DTD/entity declarations.
+
+    Returns an ElementTree (same surface as ET.parse) so callers can keep using
+    .getroot()/.iter(). Raises UnsafeXMLError on a rejected input and the usual
+    ET.ParseError on malformed XML.
+    """
+    data = Path(path).read_bytes()
+    if len(data) > max_bytes:
+        raise UnsafeXMLError(
+            f"XML input {path} is {len(data)} bytes, over the {max_bytes}-byte limit"
+        )
+    lowered = data.lower()
+    if b"<!doctype" in lowered or b"<!entity" in lowered:
+        raise UnsafeXMLError(
+            f"XML input {path} declares a DTD/ENTITY, which is rejected "
+            "(XXE / entity-expansion guard)"
+        )
+    return ET.ElementTree(ET.fromstring(data))

--- a/src/tools/coverage_intel.py
+++ b/src/tools/coverage_intel.py
@@ -7,6 +7,11 @@ import sqlite3
 import subprocess
 import xml.etree.ElementTree as ET
 from pathlib import Path
+
+try:
+    from ..safe_xml import safe_parse_xml, UnsafeXMLError
+except ImportError:  # imported with src/ directly on sys.path
+    from safe_xml import safe_parse_xml, UnsafeXMLError
 from typing import Dict, List, Optional, Set, Tuple
 
 try:
@@ -160,7 +165,7 @@ def _parse_coverage_xml(xml_path: str) -> Dict[str, Set[int]]:
     result: Dict[str, Set[int]] = {}
 
     try:
-        tree = ET.parse(xml_path)
+        tree = safe_parse_xml(xml_path)
         root = tree.getroot()
 
         for cls in root.iter("class"):
@@ -181,7 +186,7 @@ def _parse_coverage_xml(xml_path: str) -> Dict[str, Set[int]]:
             else:
                 result[filename] = lines
 
-    except (ET.ParseError, OSError):
+    except (ET.ParseError, OSError, UnsafeXMLError):
         pass
 
     return result

--- a/tests/test_architecture.py
+++ b/tests/test_architecture.py
@@ -71,7 +71,7 @@ class TestZeroDependency:
     INTERNAL_MODULES = {
         "src", "models", "analyzer", "scanner", "tools", "lsp", "indexer",
         "mapper", "context", "auditor", "engine", "bm25", "semantic",
-        "safe_io", "index_store", "quality", "diff_impact", "signature",
+        "safe_io", "safe_xml", "index_store", "quality", "diff_impact", "signature",
         "tool_registry", "mcp_server", "cli", "project_profile",
         "secret_scanner", "dependency_scanner", "iac_scanner",
         "license_scanner", "doc_scanner", "pr_analyzer", "sbom_export",

--- a/tests/test_security_hardening.py
+++ b/tests/test_security_hardening.py
@@ -1,0 +1,111 @@
+"""Security-hardening tests: HTTP body/DoS bounds + XXE-safe XML parsing."""
+
+import io
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from api_server import (
+    APIHandler,
+    MAX_BODY_BYTES,
+    MAX_SEARCH_RESULTS,
+    _BadRequest,
+    _PayloadTooLarge,
+    _clamp_max_results,
+)
+from safe_xml import safe_parse_xml, UnsafeXMLError
+
+
+def _handler_with_body(content_length, body: bytes) -> APIHandler:
+    """Build an APIHandler without a real socket to exercise _read_json."""
+    h = APIHandler.__new__(APIHandler)
+    h.headers = {"Content-Length": str(content_length)}
+    h.rfile = io.BytesIO(body)
+    return h
+
+
+class TestReadJsonBounds:
+    def test_oversized_body_is_rejected_before_read(self):
+        # Declares a huge body but supplies none — must reject on the header,
+        # never attempting an unbounded allocation/read.
+        h = _handler_with_body(MAX_BODY_BYTES + 1, b"")
+        with pytest.raises(_PayloadTooLarge):
+            h._read_json()
+
+    def test_invalid_content_length_is_bad_request(self):
+        h = APIHandler.__new__(APIHandler)
+        h.headers = {"Content-Length": "not-a-number"}
+        h.rfile = io.BytesIO(b"")
+        with pytest.raises(_BadRequest):
+            h._read_json()
+
+    def test_malformed_json_is_bad_request(self):
+        body = b"{not valid json"
+        h = _handler_with_body(len(body), body)
+        with pytest.raises(_BadRequest):
+            h._read_json()
+
+    def test_valid_body_parses(self):
+        body = b'{"query": "hi", "max_results": 5}'
+        h = _handler_with_body(len(body), body)
+        assert h._read_json() == {"query": "hi", "max_results": 5}
+
+    def test_empty_body_is_empty_dict(self):
+        h = _handler_with_body(0, b"")
+        assert h._read_json() == {}
+
+
+class TestClampMaxResults:
+    @pytest.mark.parametrize("value,expected", [
+        (5, 5),
+        (0, 1),
+        (-3, 1),
+        (10_000, MAX_SEARCH_RESULTS),
+        ("7", 7),
+        ("garbage", 10),
+        (None, 10),
+    ])
+    def test_clamp(self, value, expected):
+        assert _clamp_max_results(value) == expected
+
+
+class TestSafeXML:
+    def test_parses_valid_coverage_xml(self, tmp_path):
+        p = tmp_path / "coverage.xml"
+        p.write_text(
+            '<coverage><class filename="a.py">'
+            '<line number="1" hits="1"/></class></coverage>'
+        )
+        tree = safe_parse_xml(p)
+        assert tree.getroot().tag == "coverage"
+
+    def test_rejects_doctype_xxe(self, tmp_path):
+        p = tmp_path / "evil.xml"
+        p.write_text(
+            '<?xml version="1.0"?>\n'
+            '<!DOCTYPE foo [<!ENTITY xxe SYSTEM "file:///etc/passwd">]>\n'
+            "<coverage>&xxe;</coverage>"
+        )
+        with pytest.raises(UnsafeXMLError):
+            safe_parse_xml(p)
+
+    def test_rejects_entity_billion_laughs(self, tmp_path):
+        p = tmp_path / "lol.xml"
+        p.write_text(
+            '<?xml version="1.0"?>\n'
+            '<!DOCTYPE lolz [<!ENTITY lol "lol">'
+            '<!ENTITY lol2 "&lol;&lol;&lol;">]>\n'
+            "<root>&lol2;</root>"
+        )
+        with pytest.raises(UnsafeXMLError):
+            safe_parse_xml(p)
+
+    def test_rejects_oversized(self, tmp_path):
+        p = tmp_path / "big.xml"
+        p.write_text("<root/>")
+        with pytest.raises(UnsafeXMLError):
+            safe_parse_xml(p, max_bytes=3)


### PR DESCRIPTION
Two unauthenticated, untrusted-input hardening fixes. The indexer ingests repositories it does not control, so these inputs are attacker-controlled by design.

## H-10 — HTTP server DoS (`api_server.py`)
Single-threaded `HTTPServer` bound to `0.0.0.0`, no body limit, no socket timeout. One connection could declare a giant `Content-Length` (unbounded `self.rfile.read()` → OOM) or trickle a slow body to pin the only serving thread (slow-loris) — taking the whole service down.

- Reject `Content-Length` over **`MAX_BODY_BYTES` (4 MiB)** before reading; reject invalid/negative → JSON **413/400** instead of crashing.
- Catch malformed JSON → **400** (was an unhandled 500/stacktrace).
- Per-connection socket timeout (`handler.timeout`) bounds slow-loris; switch to **`ThreadingHTTPServer`** so one slow client can't block others.
- Default bind **`127.0.0.1`** (this service has no auth) instead of `0.0.0.0`.
- Clamp client-supplied `max_results` to `[1, 100]`.

## P1-8 — XXE / billion-laughs (`safe_xml.py` → `dependency_scanner` pom.xml + `tools/coverage_intel` coverage.xml)
Stdlib `xml.etree` is vulnerable to XXE / entity-expansion via DTDs — and the indexer's *own* taint rules flag `etree.parse` as high-risk. New **dependency-free** `safe_parse_xml` caps input size and rejects any `DOCTYPE`/`ENTITY` declaration up front (neither pom.xml nor coverage.xml legitimately uses one), closing external- and internal-entity attacks. The package stays **zero-dependency** (`safe_xml` is stdlib-only; added to the architecture guard's internal-module allowlist, alongside `safe_io`).

## Verification
- New `tests/test_security_hardening.py`: oversized body → 413, malformed JSON → 400, invalid Content-Length, `max_results` clamp, and XXE / billion-laughs / oversize XML rejection + valid-parse.
- Full suite green: **1477 passed, 2 skipped**; the zero-dependency architecture guard (`test_architecture.py`) still passes.

## Follow-up (separate PR, P1-9)
Sandbox/gate the `validate_changes`/`pytest` path — `pytest` auto-imports `conftest.py` from an untrusted scanned tree (arbitrary code execution). Not in scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)