### PR TITLE
security(validation): gate test execution (conftest RCE) + harden test_path/git ref (P1-9)

### DIFF
--- a/src/diff_impact.py
+++ b/src/diff_impact.py
@@ -55,6 +55,11 @@ def _run_git_diff(root: str, mode: str, base: str) -> str:
     Returns:
         Raw unified diff text
     """
+    # SECURITY: a base ref starting with '-' would be parsed by git as an option
+    # (argument injection). Refuse it; the ref is interpolated into the command.
+    if base and base.startswith("-"):
+        raise ValueError("invalid base ref: must not start with '-'")
+
     cmd = ["git", "-C", root, "diff", "--unified=0", "--no-color"]
 
     if mode == "staged":

--- a/src/tools/validation.py
+++ b/src/tools/validation.py
@@ -5,9 +5,37 @@ Usage:
     validate_changes(project="flyto-indexer", run_tests=True)
 """
 
+import os
 import subprocess
 import re
 from pathlib import Path
+
+# pytest auto-imports conftest.py from the tree it runs against, so executing it
+# on an ingested/untrusted repository is arbitrary code execution. Gate it behind
+# an explicit opt-in.
+_ALLOW_TEST_EXECUTION_ENV = "FLYTO_ALLOW_TEST_EXECUTION"
+_TRUTHY = {"1", "true", "yes", "on"}
+
+
+def _test_execution_allowed() -> bool:
+    return os.environ.get(_ALLOW_TEST_EXECUTION_ENV, "").strip().lower() in _TRUTHY
+
+
+def _validate_test_path(test_path: str, project_root: str):
+    """Confine test_path to a relative path inside project_root.
+
+    Returns (True, relative_path) or (False, error_message). Rejects a leading
+    '-' (pytest argument injection) and any path that escapes the project root.
+    """
+    if test_path.startswith("-"):
+        return False, "invalid test_path: must not start with '-'"
+    root = Path(project_root).resolve()
+    candidate = (root / test_path).resolve()
+    try:
+        rel = candidate.relative_to(root)
+    except ValueError:
+        return False, "invalid test_path: escapes the project root"
+    return True, str(rel)
 
 try:
     from ..index_store import load_index
@@ -82,7 +110,29 @@ def _run_pytest(project_root: str, test_path: str = None) -> dict:
         "output": "",
     }
 
-    cmd = ["python", "-m", "pytest", test_path or ".", "-x", "--tb=short", "-q"]
+    # SECURITY: refuse to execute tests unless explicitly opted in — pytest
+    # auto-imports conftest.py from the target tree (code execution on an
+    # untrusted/ingested repo).
+    if not _test_execution_allowed():
+        result["output"] = (
+            "test execution disabled: pytest auto-imports conftest.py from the "
+            "target tree, which is arbitrary code execution on untrusted repos. "
+            f"Set {_ALLOW_TEST_EXECUTION_ENV}=1 to enable."
+        )
+        return result
+
+    # SECURITY: confine the target to a relative path inside project_root and
+    # pass it after '--' so it can never be parsed as a pytest option.
+    target = "."
+    if test_path:
+        ok, value = _validate_test_path(test_path, project_root)
+        if not ok:
+            result["status"] = "error"
+            result["output"] = value
+            return result
+        target = value
+
+    cmd = ["python", "-m", "pytest", "-x", "--tb=short", "-q", "--", target]
 
     try:
         proc = subprocess.run(

--- a/tests/test_validation_security.py
+++ b/tests/test_validation_security.py
@@ -1,0 +1,57 @@
+"""Security tests: gate untrusted test execution (conftest RCE) + git ref injection."""
+
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from tools.validation import _run_pytest, _validate_test_path, _test_execution_allowed
+import diff_impact
+
+
+class TestValidateTestPath:
+    def test_rejects_leading_dash(self, tmp_path):
+        ok, msg = _validate_test_path("-x", str(tmp_path))
+        assert ok is False
+        assert "start with '-'" in msg
+
+    def test_rejects_escape(self, tmp_path):
+        ok, msg = _validate_test_path("../../etc/passwd", str(tmp_path))
+        assert ok is False
+        assert "escapes" in msg
+
+    def test_accepts_inside(self, tmp_path):
+        (tmp_path / "tests").mkdir()
+        ok, rel = _validate_test_path("tests", str(tmp_path))
+        assert ok is True
+        assert rel == "tests"
+
+
+class TestPytestOptIn:
+    def test_disabled_by_default(self, monkeypatch, tmp_path):
+        monkeypatch.delenv("FLYTO_ALLOW_TEST_EXECUTION", raising=False)
+        assert _test_execution_allowed() is False
+        result = _run_pytest(str(tmp_path))
+        assert result["status"] == "skipped"
+        assert "test execution disabled" in result["output"]
+        assert "conftest.py" in result["output"]
+
+    def test_bad_test_path_rejected_even_when_enabled(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("FLYTO_ALLOW_TEST_EXECUTION", "1")
+        result = _run_pytest(str(tmp_path), test_path="../../etc")
+        assert result["status"] == "error"
+        assert "escapes" in result["output"]
+
+    def test_leading_dash_rejected_when_enabled(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("FLYTO_ALLOW_TEST_EXECUTION", "1")
+        result = _run_pytest(str(tmp_path), test_path="-x")
+        assert result["status"] == "error"
+        assert "start with '-'" in result["output"]
+
+
+class TestGitRefInjection:
+    def test_rejects_option_like_base(self, tmp_path):
+        with pytest.raises(ValueError, match="must not start with '-'"):
+            diff_impact._run_git_diff(str(tmp_path), "committed", "--output=/tmp/x")


### PR DESCRIPTION
`validate_changes`/`_run_pytest` ran `pytest` against an ingested project root. **pytest auto-imports `conftest.py` from the target tree**, so scanning an untrusted repo was **arbitrary code execution** with the indexer's privileges. `test_path` was also passed straight into the pytest argv (option injection), and `diff_impact`'s `base` ref was interpolated into `git diff` (option injection).

## Fix
- `_run_pytest` refuses to run unless **`FLYTO_ALLOW_TEST_EXECUTION=1`** is set (default: `skipped`, with a message naming the conftest risk).
- `_validate_test_path` confines `test_path` to a relative path inside `project_root`, rejects a leading `-`, and the target is passed after `--` so pytest can never parse it as an option.
- `diff_impact._run_git_diff` rejects a `base` ref starting with `-`.

## Verification
`tests/test_validation_security.py`: pytest disabled by default + conftest message; bad / escaping / leading-dash `test_path` rejected even when enabled; git `base` ref starting with `-` raises. Full suite green: **1468 passed, 2 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)