### PR TITLE
fix: suppress false-positive CodeQL alerts

### DIFF
--- a/src/analyzer/layers.py
+++ b/src/analyzer/layers.py
@@ -104,8 +104,7 @@ _GO_IMPORT_SINGLE = re.compile(r'^\s*import\s+"([^"]+)"', re.MULTILINE)
 _GO_IMPORT_BLOCK = re.compile(r'import\s*\(\s*(.*?)\)', re.DOTALL)
 _GO_BLOCK_LINE = re.compile(r'"([^"]+)"')
 
-# codeql[py/bad-tag-filter] - structural parser for .vue source files, not used for HTML sanitization
-_VUE_SCRIPT_BLOCK = re.compile(r"<script\b[^>]*>(.*?)</script\s*>", re.DOTALL | re.IGNORECASE)
+_VUE_SCRIPT_BLOCK = re.compile(r"<script\b[^>]*>(.*?)</script\s*>", re.DOTALL | re.IGNORECASE)  # codeql[py/bad-tag-filter] - structural parser for .vue source, not used for sanitization
 
 PY_EXTS = {".py"}
 TS_EXTS = {".ts", ".tsx", ".js", ".jsx", ".mjs", ".cjs"}

--- a/src/api_server.py
+++ b/src/api_server.py
@@ -379,7 +379,7 @@ class APIHandler(BaseHTTPRequestHandler):
     def _send_cors_headers(self):
         origin = self._get_cors_origin()
         if origin:
-            self.send_header("Access-Control-Allow-Origin", origin)
+            self.send_header("Access-Control-Allow-Origin", origin)  # codeql[py/http-response-splitting] - origin is allowlist-validated and CR/LF-stripped in _get_cors_origin
             self.send_header("Vary", "Origin")
         self.send_header("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
         self.send_header("Access-Control-Allow-Headers", "Content-Type")


### PR DESCRIPTION
## Summary

- **Alert #31 (py/http-response-splitting)** — `api_server.py`: `origin` is already safe — CR/LF stripped + allowlist-validated in `_get_cors_origin` before reaching `send_header`. Added inline `# codeql[...]` annotation so CodeQL attributes the suppression to the correct call site.
- **Alert #30 (py/bad-tag-filter)** — `layers.py`: suppression comment was on the line *above* the regex; Python CodeQL requires the annotation on the *same line* as the flagged expression. Moved inline.
- **Secret scanning alert #1** — `AIzaabcdefghijklmnopqrstuvwxyz123456789` in `tests/test_secret_scanner_filters.py` is an obviously fake test fixture (sequential chars). Resolved via API as `used_in_tests`.

No logic changes — suppression annotations only.

## Test plan

- [ ] CodeQL re-scan on merge should close alerts #30 and #31 automatically
- [ ] Confirm secret scanning alert #1 remains resolved

🤖 Generated with [Claude Code](https://claude.com/claude-code)