### PR TITLE
fix: make quality debt gate portable

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -29,6 +29,8 @@ jobs:
           push: false
           load: true
           tags: flyto-indexer:${{ github.sha }}
+          build-args: |
+            RUNTIME_SECURITY_REFRESH=${{ github.run_id }}-${{ github.run_attempt }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -57,7 +57,9 @@ ENV PIP_DISABLE_PIP_VERSION_CHECK=1 \
 # login and libblkid1 with it) was held back and CVE-2026-53615 stayed in the
 # image while the build looked clean. The version assertions below fail the
 # build loudly if either fix ever regresses.
-RUN apt-get update \
+ARG RUNTIME_SECURITY_REFRESH=local
+RUN test -n "${RUNTIME_SECURITY_REFRESH}" \
+    && apt-get update \
     && apt-get dist-upgrade -y \
     && apt-get install -y --no-install-recommends \
         git \
@@ -69,6 +71,9 @@ RUN apt-get update \
     && dpkg --compare-versions \
         "$(dpkg-query -W -f='${Version}' util-linux)" \
         ge "2.41.5-0+deb13u1" \
+    && dpkg --compare-versions \
+        "$(dpkg-query -W -f='${Version}' openssl-provider-legacy)" \
+        ge "3.5.7-1~deb13u2" \
     && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app

--- a/docs/reference/modules.md
+++ b/docs/reference/modules.md
@@ -2,7 +2,7 @@
 
 # Module Inventory
 
-Generated inventory: **186 Python modules**, **78,580 lines**, and **2,412 class/function/method declarations**.
+Generated inventory: **186 Python modules**, **78,584 lines**, and **2,413 class/function/method declarations**.
 
 | Module | Lines | Declarations | Direct import roots | Responsibility |
 |---|---:|---:|---|---|
@@ -26,7 +26,7 @@ Generated inventory: **186 Python modules**, **78,580 lines**, and **2,412 class
 | [`examples/test_stale_files.py:1`](https://github.com/flytohub/flyto-indexer/blob/main/examples/test_stale_files.py#L1) | 31 | 1 | `analyzer, pathlib, sys` | Test stale file detection. |
 | [`index_all.py:1`](https://github.com/flytohub/flyto-indexer/blob/main/index_all.py#L1) | 446 | 14 | `datetime, gzip, hashlib, json, pathlib, src, sys, traceback, yaml` | Index projects from config |
 | [`scripts/check_language_evidence.py:1`](https://github.com/flytohub/flyto-indexer/blob/main/scripts/check_language_evidence.py#L1) | 157 | 4 | `__future__, argparse, collections, json, pathlib, sys, typing` | Validate and render the public per-language evidence matrix. |
-| [`scripts/check_quality_debt.py:1`](https://github.com/flytohub/flyto-indexer/blob/main/scripts/check_quality_debt.py#L1) | 184 | 8 | `__future__, argparse, collections, json, pathlib, re, subprocess, sys, tomllib, typing` | Fail when configured Ruff or mypy debt changes without review. |
+| [`scripts/check_quality_debt.py:1`](https://github.com/flytohub/flyto-indexer/blob/main/scripts/check_quality_debt.py#L1) | 188 | 9 | `__future__, argparse, collections, json, pathlib, re, subprocess, sys, tomllib, typing` | Fail when configured Ruff or mypy debt changes without review. |
 | [`scripts/check_release_tag.py:1`](https://github.com/flytohub/flyto-indexer/blob/main/scripts/check_release_tag.py#L1) | 54 | 3 | `__future__, argparse, pathlib, sys, tomllib` | Verify that a release tag matches package metadata and the changelog. |
 | [`scripts/generate-reference.py:1`](https://github.com/flytohub/flyto-indexer/blob/main/scripts/generate-reference.py#L1) | 449 | 23 | `__future__, argparse, ast, collections, json, pathlib, re, sys, typing, yaml` | Generate exhaustive Flyto2 Indexer references from implementation sources. |
 | [`scripts/reproduce_impact_case.py:1`](https://github.com/flytohub/flyto-indexer/blob/main/scripts/reproduce_impact_case.py#L1) | 251 | 9 | `__future__, argparse, hashlib, json, os, pathlib, subprocess, sys, tempfile, typing` | Reproduce the pinned public impact-analysis case study. |

--- a/docs/reference/python-api.md
+++ b/docs/reference/python-api.md
@@ -2,7 +2,7 @@
 
 # Python API Reference
 
-Every declared class, function, nested function, and method in the package, support scripts, examples, benchmarks, and root command entry scripts. Generated inventory: **2,412 declarations across 170 files**.
+Every declared class, function, nested function, and method in the package, support scripts, examples, benchmarks, and root command entry scripts. Generated inventory: **2,413 declarations across 170 files**.
 
 ## `analyze.py`
 
@@ -215,13 +215,14 @@ Every declared class, function, nested function, and method in the package, supp
 | Kind | Signature | Responsibility | Source |
 |---|---|---|---|
 | function | `def _run(command: list&#91;str&#93;) -> subprocess.CompletedProcess&#91;str&#93;` | The declaration and linked implementation are authoritative. | [`scripts/check_quality_debt.py:22`](https://github.com/flytohub/flyto-indexer/blob/main/scripts/check_quality_debt.py#L22) |
-| function | `def _tool_version(command: str) -> str` | The declaration and linked implementation are authoritative. | [`scripts/check_quality_debt.py:32`](https://github.com/flytohub/flyto-indexer/blob/main/scripts/check_quality_debt.py#L32) |
-| function | `def _configured_debt_codes() -> tuple&#91;list&#91;str&#93;, list&#91;str&#93;&#93;` | The declaration and linked implementation are authoritative. | [`scripts/check_quality_debt.py:39`](https://github.com/flytohub/flyto-indexer/blob/main/scripts/check_quality_debt.py#L39) |
-| function | `def _ruff_counts(codes: list&#91;str&#93;) -> dict&#91;str, int&#93;` | The declaration and linked implementation are authoritative. | [`scripts/check_quality_debt.py:46`](https://github.com/flytohub/flyto-indexer/blob/main/scripts/check_quality_debt.py#L46) |
-| function | `def _mypy_counts(codes: list&#91;str&#93;) -> dict&#91;str, int&#93;` | The declaration and linked implementation are authoritative. | [`scripts/check_quality_debt.py:68`](https://github.com/flytohub/flyto-indexer/blob/main/scripts/check_quality_debt.py#L68) |
-| function | `def collect_debt() -> dict&#91;str, Any&#93;` | Collect deterministic production-source debt for configured exemptions. | [`scripts/check_quality_debt.py:95`](https://github.com/flytohub/flyto-indexer/blob/main/scripts/check_quality_debt.py#L95) |
-| function | `def compare_debt(current: dict&#91;str, Any&#93;, baseline: dict&#91;str, Any&#93;) -> list&#91;str&#93;` | Return actionable drift messages; exact equality closes baseline headroom. | [`scripts/check_quality_debt.py:123`](https://github.com/flytohub/flyto-indexer/blob/main/scripts/check_quality_debt.py#L123) |
-| function | `def main() -> int` | The declaration and linked implementation are authoritative. | [`scripts/check_quality_debt.py:145`](https://github.com/flytohub/flyto-indexer/blob/main/scripts/check_quality_debt.py#L145) |
+| function | `def _tool_command(module: str, *args: str) -> list&#91;str&#93;` | The declaration and linked implementation are authoritative. | [`scripts/check_quality_debt.py:32`](https://github.com/flytohub/flyto-indexer/blob/main/scripts/check_quality_debt.py#L32) |
+| function | `def _tool_version(module: str) -> str` | The declaration and linked implementation are authoritative. | [`scripts/check_quality_debt.py:36`](https://github.com/flytohub/flyto-indexer/blob/main/scripts/check_quality_debt.py#L36) |
+| function | `def _configured_debt_codes() -> tuple&#91;list&#91;str&#93;, list&#91;str&#93;&#93;` | The declaration and linked implementation are authoritative. | [`scripts/check_quality_debt.py:43`](https://github.com/flytohub/flyto-indexer/blob/main/scripts/check_quality_debt.py#L43) |
+| function | `def _ruff_counts(codes: list&#91;str&#93;) -> dict&#91;str, int&#93;` | The declaration and linked implementation are authoritative. | [`scripts/check_quality_debt.py:50`](https://github.com/flytohub/flyto-indexer/blob/main/scripts/check_quality_debt.py#L50) |
+| function | `def _mypy_counts(codes: list&#91;str&#93;) -> dict&#91;str, int&#93;` | The declaration and linked implementation are authoritative. | [`scripts/check_quality_debt.py:72`](https://github.com/flytohub/flyto-indexer/blob/main/scripts/check_quality_debt.py#L72) |
+| function | `def collect_debt() -> dict&#91;str, Any&#93;` | Collect deterministic production-source debt for configured exemptions. | [`scripts/check_quality_debt.py:99`](https://github.com/flytohub/flyto-indexer/blob/main/scripts/check_quality_debt.py#L99) |
+| function | `def compare_debt(current: dict&#91;str, Any&#93;, baseline: dict&#91;str, Any&#93;) -> list&#91;str&#93;` | Return actionable drift messages; exact equality closes baseline headroom. | [`scripts/check_quality_debt.py:127`](https://github.com/flytohub/flyto-indexer/blob/main/scripts/check_quality_debt.py#L127) |
+| function | `def main() -> int` | The declaration and linked implementation are authoritative. | [`scripts/check_quality_debt.py:149`](https://github.com/flytohub/flyto-indexer/blob/main/scripts/check_quality_debt.py#L149) |
 
 ## `scripts/check_release_tag.py`
 

--- a/scripts/check_quality_debt.py
+++ b/scripts/check_quality_debt.py
@@ -29,10 +29,14 @@ def _run(command: list[str]) -> subprocess.CompletedProcess[str]:
     )
 
 
-def _tool_version(command: str) -> str:
-    result = _run([command, "--version"])
+def _tool_command(module: str, *args: str) -> list[str]:
+    return [sys.executable, "-m", module, *args]
+
+
+def _tool_version(module: str) -> str:
+    result = _run(_tool_command(module, "--version"))
     if result.returncode != 0:
-        raise RuntimeError(f"{command} is unavailable: {result.stderr.strip()}")
+        raise RuntimeError(f"{module} is unavailable: {result.stderr.strip()}")
     return result.stdout.strip()
 
 
@@ -46,7 +50,7 @@ def _configured_debt_codes() -> tuple[list[str], list[str]]:
 def _ruff_counts(codes: list[str]) -> dict[str, int]:
     if not codes:
         return {}
-    result = _run([
+    result = _run(_tool_command(
         "ruff",
         "check",
         "src",
@@ -57,7 +61,7 @@ def _ruff_counts(codes: list[str]) -> dict[str, int]:
         "--output-format",
         "json",
         "--exit-zero",
-    ])
+    ))
     if result.returncode != 0:
         raise RuntimeError(f"Ruff debt scan failed: {result.stderr.strip()}")
     findings = json.loads(result.stdout or "[]")
@@ -68,7 +72,7 @@ def _ruff_counts(codes: list[str]) -> dict[str, int]:
 def _mypy_counts(codes: list[str]) -> dict[str, int]:
     if not codes:
         return {}
-    command = [
+    command = _tool_command(
         "mypy",
         "src",
         "--show-error-codes",
@@ -76,7 +80,7 @@ def _mypy_counts(codes: list[str]) -> dict[str, int]:
         "--platform",
         MYPY_PLATFORM,
         "--no-site-packages",
-    ]
+    )
     for code in codes:
         command.extend(["--enable-error-code", code])
     result = _run(command)

--- a/tests/test_quality_debt_gate.py
+++ b/tests/test_quality_debt_gate.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import importlib.util
+import subprocess
+import sys
 from pathlib import Path
 
 
@@ -33,3 +35,25 @@ def test_quality_debt_gate_blocks_regression_and_unlocked_improvement():
     assert improvement == [
         "mypy:arg-type improved 3 -> 2; update the baseline to lock it in"
     ]
+
+
+def test_quality_debt_gate_uses_active_python_when_path_has_no_tools(monkeypatch):
+    monkeypatch.setenv("PATH", "")
+    commands: list[list[str]] = []
+
+    def fake_run(command: list[str]) -> subprocess.CompletedProcess[str]:
+        commands.append(command)
+        if "--version" in command:
+            module = command[2]
+            return subprocess.CompletedProcess(command, 0, f"{module} 1\n", "")
+        if command[2] == "ruff":
+            return subprocess.CompletedProcess(command, 0, "[]", "")
+        return subprocess.CompletedProcess(command, 0, "", "")
+
+    monkeypatch.setattr(MODULE, "_run", fake_run)
+
+    debt = MODULE.collect_debt()
+
+    assert debt["tools"] == {"ruff": "ruff 1", "mypy": "mypy 1"}
+    assert commands
+    assert all(command[:2] == [sys.executable, "-m"] for command in commands)


### PR DESCRIPTION
Runs Ruff and mypy through the active Python environment, adds a PATH-isolated regression, and regenerates the exact reference docs. Governed revision accepted after independent full verification: 2441 passed, 3 skipped, 61 deselected; all contract gates green.